### PR TITLE
Add CoreUtils and SystemInfo modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Use Debian as the base image
+FROM debian:bullseye
+
+# Install required packages
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    g++ \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy the project files
+COPY . .
+
+# Remove any existing build directory and CMake cache
+RUN rm -rf build CMakeCache.txt
+
+# Create build directory and build the project
+RUN mkdir build && \
+    cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release .. && \
+    make
+
+# Run the example
+CMD ["./build/CoreUtilsExample"]

--- a/example/example.cxx
+++ b/example/example.cxx
@@ -1,0 +1,3 @@
+int main() {
+    return 0;
+}

--- a/example/example.cxx
+++ b/example/example.cxx
@@ -1,3 +1,20 @@
+#include "../src/CoreUtils.hxx"
+#include <iostream>
+
 int main() {
+    CoreUtils::Utils::initialize();
+    std::cout << "System Information Demo\n";
+    std::cout << "=======================\n";
+    std::cout << "Hostname: " << CoreUtils::System::getHostname() << "\n";
+    std::cout << "Kernel: " << CoreUtils::System::getKernelVersion() << "\n";
+    std::cout << "Distribution: " << CoreUtils::System::getDistribution() << "\n";
+    std::cout << "Uptime: " << CoreUtils::System::getUptime() << " seconds\n";
+    std::cout << "CPU Count: " << CoreUtils::System::getCpuCount() << "\n";
+
+    auto cpuInfo = CoreUtils::System::getCpuInfo();
+    std::cout << "CPU Model: " << cpuInfo.model_name << "\n";
+    std::cout << "CPU Frequency: " << cpuInfo.frequency_mhz << " MHz\n";
+
+    CoreUtils::Utils::cleanup();
     return 0;
 }

--- a/src/CoreUtils.cxx
+++ b/src/CoreUtils.cxx
@@ -1,0 +1,70 @@
+#include "CoreUtils.hxx"
+
+namespace CoreUtils {
+
+    // Static member definitions
+    std::unique_ptr<SystemInfo> CoreUtils::s_system_info = nullptr;
+    bool CoreUtils::s_initialized = false;
+
+    SystemInfo& CoreUtils::getSystemInfo() {
+        if (!s_system_info) {
+            s_system_info = std::make_unique<SystemInfo>();
+        }
+        return *s_system_info;
+    }
+
+    const char* CoreUtils::getVersion() {
+        return VERSION;
+    }
+
+    const char* CoreUtils::getBuildDate() {
+        return BUILD_DATE;
+    }
+
+    void CoreUtils::initialize() {
+        if (!s_initialized) {
+            // Future initialization code can go here
+            s_initialized = true;
+        }
+    }
+
+    void CoreUtils::cleanup() {
+        if (s_initialized) {
+            s_system_info.reset();
+            s_initialized = false;
+        }
+    }
+
+    // Convenience functions in System namespace
+    namespace System {
+
+        std::string getHostname() {
+            return CoreUtils::getSystemInfo().getHostname();
+        }
+
+        std::string getKernelVersion() {
+            return CoreUtils::getSystemInfo().getKernelVersion();
+        }
+
+        std::string getDistribution() {
+            return CoreUtils::getSystemInfo().getDistribution();
+        }
+
+        long getUptime() {
+            return CoreUtils::getSystemInfo().getUptime();
+        }
+
+        int getCpuCount() {
+            return CoreUtils::getSystemInfo().getCpuCount();
+        }
+
+        LoadAverage getLoadAverage() {
+            return CoreUtils::getSystemInfo().getLoadAverage();
+        }
+
+        CpuInfo getCpuInfo() {
+            return CoreUtils::getSystemInfo().getCpuInfo();
+        }
+    }
+
+}

--- a/src/CoreUtils.cxx
+++ b/src/CoreUtils.cxx
@@ -3,32 +3,36 @@
 namespace CoreUtils {
 
     // Static member definitions
-    std::unique_ptr<SystemInfo> CoreUtils::s_system_info = nullptr;
-    bool CoreUtils::s_initialized = false;
+    std::unique_ptr<SystemInfo> Utils::s_system_info = nullptr;
+    bool Utils::s_initialized = false;
+    std::mutex Utils::s_mutex;
 
-    SystemInfo& CoreUtils::getSystemInfo() {
+    SystemInfo& Utils::getSystemInfo() {
+        std::lock_guard<std::mutex> lock(s_mutex);
         if (!s_system_info) {
             s_system_info = std::make_unique<SystemInfo>();
         }
         return *s_system_info;
     }
 
-    const char* CoreUtils::getVersion() {
+    const char* Utils::getVersion() {
         return VERSION;
     }
 
-    const char* CoreUtils::getBuildDate() {
+    const char* Utils::getBuildDate() {
         return BUILD_DATE;
     }
 
-    void CoreUtils::initialize() {
+    void Utils::initialize() {
+        std::lock_guard<std::mutex> lock(s_mutex);
         if (!s_initialized) {
             // Future initialization code can go here
             s_initialized = true;
         }
     }
 
-    void CoreUtils::cleanup() {
+    void Utils::cleanup() {
+        std::lock_guard<std::mutex> lock(s_mutex);
         if (s_initialized) {
             s_system_info.reset();
             s_initialized = false;
@@ -39,31 +43,31 @@ namespace CoreUtils {
     namespace System {
 
         std::string getHostname() {
-            return CoreUtils::getSystemInfo().getHostname();
+            return Utils::getSystemInfo().getHostname();
         }
 
         std::string getKernelVersion() {
-            return CoreUtils::getSystemInfo().getKernelVersion();
+            return Utils::getSystemInfo().getKernelVersion();
         }
 
         std::string getDistribution() {
-            return CoreUtils::getSystemInfo().getDistribution();
+            return Utils::getSystemInfo().getDistribution();
         }
 
         long getUptime() {
-            return CoreUtils::getSystemInfo().getUptime();
+            return Utils::getSystemInfo().getUptime();
         }
 
         int getCpuCount() {
-            return CoreUtils::getSystemInfo().getCpuCount();
+            return Utils::getSystemInfo().getCpuCount();
         }
 
         LoadAverage getLoadAverage() {
-            return CoreUtils::getSystemInfo().getLoadAverage();
+            return Utils::getSystemInfo().getLoadAverage();
         }
 
         CpuInfo getCpuInfo() {
-            return CoreUtils::getSystemInfo().getCpuInfo();
+            return Utils::getSystemInfo().getCpuInfo();
         }
     }
 

--- a/src/CoreUtils.hxx
+++ b/src/CoreUtils.hxx
@@ -2,6 +2,7 @@
 
 #include "System/SystemInfo.hxx"
 #include <memory>
+#include <mutex>
 
 namespace CoreUtils {
 
@@ -10,7 +11,7 @@ namespace CoreUtils {
     constexpr const char* BUILD_DATE = __DATE__;
 
     // Main API entry point
-    class CoreUtils {
+    class Utils {
     public:
         // Get system information instance
         static SystemInfo& getSystemInfo();
@@ -27,6 +28,7 @@ namespace CoreUtils {
         // Singleton instances
         static std::unique_ptr<SystemInfo> s_system_info;
         static bool s_initialized;
+        static std::mutex s_mutex;
     };
 
     // Convenience functions for quick access

--- a/src/CoreUtils.hxx
+++ b/src/CoreUtils.hxx
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "System/SystemInfo.hxx"
+#include <memory>
+
+namespace CoreUtils {
+
+    // Version info
+    constexpr const char* VERSION = "1.0.0";
+    constexpr const char* BUILD_DATE = __DATE__;
+
+    // Main API entry point
+    class CoreUtils {
+    public:
+        // Get system information instance
+        static SystemInfo& getSystemInfo();
+
+        // Library info
+        static const char* getVersion();
+        static const char* getBuildDate();
+
+        // Initialize/cleanup (if needed for future extensions)
+        static void initialize();
+        static void cleanup();
+
+    private:
+        // Singleton instances
+        static std::unique_ptr<SystemInfo> s_system_info;
+        static bool s_initialized;
+    };
+
+    // Convenience functions for quick access
+    namespace System {
+        std::string getHostname();
+        std::string getKernelVersion();
+        std::string getDistribution();
+        long getUptime();
+        int getCpuCount();
+        LoadAverage getLoadAverage();
+        CpuInfo getCpuInfo();
+    }
+}

--- a/src/System/SystemInfo.cxx
+++ b/src/System/SystemInfo.cxx
@@ -1,0 +1,232 @@
+#include "System/SystemInfo.hxx"
+#include <fstream>
+#include <sstream>
+#include <iostream>
+#include <unistd.h>
+#include <sys/utsname.h>
+
+namespace CoreUtils {
+
+SystemInfo::SystemInfo()
+    : m_uptime(0)
+    , m_running_processes(0)
+    , m_total_processes(0)
+    , m_cpu_info_loaded(false)
+    , m_load_avg_loaded(false)
+    , m_uptime_loaded(false)
+    , m_stat_loaded(false) {
+
+    // Load hostname and kernel version once
+    struct utsname uts;
+    if (uname(&uts) == 0) {
+        m_hostname = uts.nodename;
+        m_kernel_version = uts.release;
+    }
+}
+
+std::string SystemInfo::readFile(const std::string& path) {
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        return "";
+    }
+
+    std::stringstream buffer;
+    buffer << file.rdbuf();
+    return buffer.str();
+}
+
+std::vector<std::string> SystemInfo::readLines(const std::string& path) {
+    std::vector<std::string> lines;
+    std::ifstream file(path);
+    std::string line;
+
+    while (std::getline(file, line)) {
+        lines.push_back(line);
+    }
+
+    return lines;
+}
+
+std::string SystemInfo::getHostname() {
+    return m_hostname;
+}
+
+std::string SystemInfo::getKernelVersion() {
+    return m_kernel_version;
+}
+
+std::string SystemInfo::getDistribution() {
+    // Try to read from /etc/os-release first
+    std::string content = readFile("/etc/os-release");
+    if (!content.empty()) {
+        std::istringstream iss(content);
+        std::string line;
+        while (std::getline(iss, line)) {
+            if (line.substr(0, 11) == "PRETTY_NAME") {
+                size_t pos = line.find('=');
+                if (pos != std::string::npos) {
+                    std::string name = line.substr(pos + 1);
+                    // Remove quotes
+                    if (name.front() == '"' && name.back() == '"') {
+                        name = name.substr(1, name.length() - 2);
+                    }
+                    return name;
+                }
+            }
+        }
+    }
+
+    // Fallback to /etc/issue
+    content = readFile("/etc/issue");
+    if (!content.empty()) {
+        return content.substr(0, content.find('\n'));
+    }
+
+    return "Unknown";
+}
+
+long SystemInfo::getUptime() {
+    if (!m_uptime_loaded) {
+        parseUptime();
+    }
+    return m_uptime;
+}
+
+void SystemInfo::parseUptime() {
+    std::string content = readFile("/proc/uptime");
+    if (!content.empty()) {
+        std::istringstream iss(content);
+        double uptime_seconds;
+        iss >> uptime_seconds;
+        m_uptime = static_cast<long>(uptime_seconds);
+        m_uptime_loaded = true;
+    }
+}
+
+CpuInfo SystemInfo::getCpuInfo() {
+    if (!m_cpu_info_loaded) {
+        parseCpuInfo();
+    }
+    return m_cpu_info;
+}
+
+std::string SystemInfo::parseCpuInfo() {
+    auto lines = readLines("/proc/cpuinfo");
+    int cores = 0;
+    int threads = 0;
+
+    for (const auto& line : lines) {
+        if (line.substr(0, 10) == "model name") {
+            size_t pos = line.find(':');
+            if (pos != std::string::npos && m_cpu_info.model_name.empty()) {
+                m_cpu_info.model_name = line.substr(pos + 2); // +2 to skip ': '
+            }
+        } else if (line.substr(0, 8) == "cpu MHz") {
+            size_t pos = line.find(':');
+            if (pos != std::string::npos && m_cpu_info.frequency_mhz == 0.0) {
+                m_cpu_info.frequency_mhz = std::stod(line.substr(pos + 2));
+            }
+        } else if (line.substr(0, 9) == "processor") {
+            threads++;
+        } else if (line.substr(0, 8) == "cpu cores") {
+            size_t pos = line.find(':');
+            if (pos != std::string::npos && cores == 0) {
+                cores = std::stoi(line.substr(pos + 2));
+            }
+        }
+    }
+
+    m_cpu_info.cores = cores > 0 ? cores : threads;
+    m_cpu_info.threads = threads;
+    m_cpu_info_loaded = true;
+
+    return "";
+}
+
+int SystemInfo::getCpuCount() {
+    if (!m_cpu_info_loaded) {
+        parseCpuInfo();
+    }
+    return m_cpu_info.threads;
+}
+
+LoadAverage SystemInfo::getLoadAverage() {
+    if (!m_load_avg_loaded) {
+        parseLoadAvg();
+    }
+    return m_load_avg;
+}
+
+void SystemInfo::parseLoadAvg() {
+    std::string content = readFile("/proc/loadavg");
+    if (!content.empty()) {
+        std::istringstream iss(content);
+        iss >> m_load_avg.one_min >> m_load_avg.five_min >> m_load_avg.fifteen_min;
+        m_load_avg_loaded = true;
+    }
+}
+
+int SystemInfo::getRunningProcesses() {
+    if (!m_stat_loaded) {
+        parseStat();
+    }
+    return m_running_processes;
+}
+
+int SystemInfo::getTotalProcesses() {
+    if (!m_stat_loaded) {
+        parseStat();
+    }
+    return m_total_processes;
+}
+
+/**
+ * Parses the system statistics from the /proc/stat file.
+ *
+ * This method reads and processes the contents of the /proc/stat
+ * file to extract relevant system statistics, such as the number of
+ * running processes and the total number of processes. The extracted
+ * information is cached in the corresponding member variables for
+ * later retrieval.
+ *
+ * Once this method is called, the system statistics are marked as
+ * loaded, and subsequent calls to retrieve process information will
+ * use the cached values unless the data is explicitly refreshed.
+ */
+void SystemInfo::parseStat() {
+    auto lines = readLines("/proc/stat");
+    for (const auto& line : lines) {
+        if (line.substr(0, 13) == "procs_running") {
+            size_t pos = line.find(' ');
+            if (pos != std::string::npos) {
+                m_running_processes = std::stoi(line.substr(pos + 1));
+            }
+        } else if (line.substr(0, 9) == "processes") {
+            size_t pos = line.find(' ');
+            if (pos != std::string::npos) {
+                m_total_processes = std::stoi(line.substr(pos + 1));
+            }
+        }
+    }
+    m_stat_loaded = true;
+}
+
+/**
+ * Resets all cached system information flags to their unloaded state.
+ *
+ * This method clears the internal flags used to indicate whether
+ * specific pieces of system information (CPU info, load average, uptime,
+ * and process statistics) have been loaded. After this method is called,
+ * these data will need to be reloaded when requested.
+ *
+ * Use this method to force the system info object to refresh its state
+ * by reloading system data from the relevant sources.
+ */
+void SystemInfo::refresh() {
+    m_cpu_info_loaded = false;
+    m_load_avg_loaded = false;
+    m_uptime_loaded = false;
+    m_stat_loaded = false;
+}
+
+}

--- a/src/System/SystemInfo.hxx
+++ b/src/System/SystemInfo.hxx
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace CoreUtils {
+
+  struct CpuInfo {
+    std::string model_name;
+    int cores;
+    int threads;
+    double frequency_mhz;
+  };
+
+  struct LoadAverage {
+    double one_min;
+    double five_min;
+    double fifteen_min;
+  };
+
+  class SystemInfo {
+  public:
+    SystemInfo();
+    ~SystemInfo() = default;
+
+    // Basic system info
+    std::string getHostname();
+    std::string getKernelVersion();
+    std::string getDistribution();
+    long getUptime(); // seconds since boot
+
+    // CPU related
+    CpuInfo getCpuInfo();
+    int getCpuCount();
+    LoadAverage getLoadAverage();
+
+    // System load and stats
+    int getRunningProcesses();
+    int getTotalProcesses();
+
+    // Refresh data from system files
+    void refresh();
+
+  private:
+    // Helper methods for reading system files
+    std::string readFile(const std::string& path);
+    std::vector<std::string> readLines(const std::string& path);
+    std::string parseCpuInfo();
+    void parseLoadAvg();
+    void parseUptime();
+    void parseStat();
+
+    // Cached data
+    CpuInfo m_cpu_info;
+    LoadAverage m_load_avg;
+    long m_uptime;
+    int m_running_processes;
+    int m_total_processes;
+    std::string m_hostname;
+    std::string m_kernel_version;
+
+    // Helper flags
+    bool m_cpu_info_loaded;
+    bool m_load_avg_loaded;
+    bool m_uptime_loaded;
+    bool m_stat_loaded;
+  };
+}


### PR DESCRIPTION
- Implement CoreUtils for library initialization, cleanup, and version info.
- Add SystemInfo class to fetch system-specific details like uptime, CPU info, load average, OS distribution, kernel version, and more.
- Introduce basic example file as a placeholder for testing functionality.